### PR TITLE
explicitly set the value of unix_socket_directory

### DIFF
--- a/recipes/server_conf.rb
+++ b/recipes/server_conf.rb
@@ -27,7 +27,7 @@ if node['platform_family'] == 'debian'
 
   if node['postgresql']['version'].to_f < 9.3
     node.normal['postgresql']['config']['unix_socket_directory'] = '/var/run/postgresql'
-  else
+  elsif !node['postgresql']['config'].key?('unix_socket_directories')
     node.normal['postgresql']['config']['unix_socket_directories'] = '/var/run/postgresql'
   end
 


### PR DESCRIPTION
### Description

Using pacemaker now, I get the following error and want to invalidate unix_socket_directories.
```
Failed Actions:
* pgsql_start_0 on staging-cmdb-2 'not configured' (6): call=9331, status=complete, exitreason='In PostgreSQL 9.3 or higher, socketdir can't be empty if you define unix_socket_directories in the postgresql.conf.'
```

### Issues Resolved

- none

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable